### PR TITLE
fix parse response in case of missing response code

### DIFF
--- a/openapi_python_client/templates/endpoint_module.py.jinja
+++ b/openapi_python_client/templates/endpoint_module.py.jinja
@@ -68,7 +68,7 @@ def _parse_response(*, client: Union[AuthenticatedClient, Client], response: htt
     if response.status_code == HTTPStatus.{{ response.status_code.name }}:
         {% if parsed_responses %}{% import "property_templates/" + response.prop.template as prop_template %}
         {% if prop_template.construct %}
-        {{ prop_template.construct(response.prop, response.source) | indent(8) }}
+        {{ prop_template.construct(response.prop, response.source.attribute) | indent(8) }}
         {% elif response.source.return_type == response.prop.get_type_string()  %}
         {{ response.prop.python_name }} = {{ response.source.attribute }}
         {% else %}

--- a/openapi_python_client/templates/endpoint_module.py.jinja
+++ b/openapi_python_client/templates/endpoint_module.py.jinja
@@ -64,10 +64,11 @@ def _get_kwargs(
 
 def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[{{ return_string }}]:
     {% for response in endpoint.responses %}
+    {% if response.source != "None" %}
     if response.status_code == HTTPStatus.{{ response.status_code.name }}:
         {% if parsed_responses %}{% import "property_templates/" + response.prop.template as prop_template %}
         {% if prop_template.construct %}
-        {{ prop_template.construct(response.prop, response.source.attribute) | indent(8) }}
+        {{ prop_template.construct(response.prop, response.source) | indent(8) }}
         {% elif response.source.return_type == response.prop.get_type_string()  %}
         {{ response.prop.python_name }} = {{ response.source.attribute }}
         {% else %}
@@ -77,6 +78,7 @@ def _parse_response(*, client: Union[AuthenticatedClient, Client], response: htt
         {% else %}
         return None
         {% endif %}
+    {% endif %}
     {% endfor %}
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)


### PR DESCRIPTION
In some cases, the response code object does not exist (response.source being None), resulting  in `cast(Any,)`